### PR TITLE
BROリリースに伴い動かなくなったのを修正

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // IntelliSense を使用して利用可能な属性を学べます。
-    // 既存の属性の説明をホバーして表示します。
-    // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
@@ -15,7 +12,6 @@
                 "Player-test.log",
                 "--read_full_log"
             ],
-            "justMyCode": true
         }
     ]
 }

--- a/app/file_version_info.txt
+++ b/app/file_version_info.txt
@@ -6,8 +6,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0.
-    filevers=(1, 6, 3, 0),
-    prodvers=(1, 6, 3, 0),
+    filevers=(1, 6, 4, 0),
+    prodvers=(1, 6, 4, 0),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -30,8 +30,8 @@ VSVersionInfo(
         StringTable(
           u'040904b0',
           [
-            StringStruct(u'FileVersion', u'1.6.3'),
-            StringStruct(u'ProductVersion', u'1.6.3')
+            StringStruct(u'FileVersion', u'1.6.4'),
+            StringStruct(u'ProductVersion', u'1.6.4')
           ]
         )
       ]

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -756,7 +756,7 @@ def parse_match_playing(blob):
     game_room_info = blob["matchGameRoomStateChangedEvent"]["gameRoomInfo"]
     game_room_players = game_room_info["players"]
     game_room_config = game_room_info["gameRoomConfig"]
-    event_id = game_room_config['eventId']
+    event_id = game_room_config.get('eventId')
 
     for player in game_room_players:
         temp_players[player["systemSeatId"]]["player_id"] = player["userId"]


### PR DESCRIPTION
matchGameRoomStateChangedEventにeventIdが無くても動くようにした